### PR TITLE
Fixed UnhandledPromiseRejectionWarning in authenticate()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,7 +273,7 @@ class Avanza extends EventEmitter {
       return Promise.reject('Missing credentials.password.')
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const data = {
         maxInactiveMinutes: MAX_INACTIVE_MINUTES,
         password: credentials.password,
@@ -302,7 +302,7 @@ class Avanza extends EventEmitter {
           pushSubscriptionId: this._pushSubscriptionId,
           customerId: this._customerId
         })
-      })
+      }).catch(e => reject(e))
     })
   }
 


### PR DESCRIPTION
Error generated when entering wrong credentials needs
to be promoted to user of API.