### PR TITLE
WebSocket enhancements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,7 +169,6 @@ class Avanza extends EventEmitter {
 
   constructor() {
     super()
-    this._socket = new WebSocket(SOCKET_URL)
     this._authenticated = false
     this._authenticationSession = null
     this._authenticationTimeout = MAX_INACTIVE_MINUTES
@@ -178,10 +177,18 @@ class Avanza extends EventEmitter {
     this._customerId = null
     this._securityToken = null
 
-    this._socketAuthenticating = false
     this._socketInitialized = false
     this._socketMessageCount = 1
     this._socketClientId = null
+    this._socketInit()
+  }
+
+  _socketInit() {
+    this._socket = new WebSocket(SOCKET_URL)
+    this._socketAuthenticating = false
+    this._socket.on('open', () => this._authenticateSocket())
+    this._socket.on('message', (data, flags) => this._socketHandleMessage(data, flags))
+    this._socket.on('close', () => this._socketInit())
   }
 
   _socketSend(data) {
@@ -193,64 +200,72 @@ class Avanza extends EventEmitter {
     const response = JSON.parse(String.fromCharCode.apply(null, flags.buffer))
     if (response.length && response[0]) {
       const message = response[0]
-      if (message.error) {
+      if (message.advice && message.advice.reconnect == 'none') {
         debug(message.error)
+      } else if (message.advice && message.advice.reconnect == 'handshake') {
+        this._authenticateSocket(true)
+      } else if (message.channel == '/meta/disconnect') {
+        // It seems Avanza send out an unsolicited /meta/disconnect *response*
+        // when session expires. Hence it should be OK to re-handshake.
+        this._authenticateSocket(true)
+      } else if (message.error) {
+        debug(message.error)
+      } else if (message.channel == '/meta/handshake') {
+        this._socketInitialized = true
+        this._socketAuthenticating = false
+        this._socketClientId = message.clientId
+        this._socketSend({
+          advice: { timeout: 0 },
+          channel: '/meta/connect',
+          clientId: this._socketClientId,
+          connectionType: 'websocket',
+          id: this._socketMessageCount,
+        })
+      } else if (message.channel == '/meta/connect') {
+        this.emit('connect', message)
+        this._socketSend({
+          channel: '/meta/connect',
+          clientId: this._socketClientId,
+          connectionType: 'websocket',
+          id: this._socketMessageCount
+        })
       } else {
-        switch (message.channel) {
-          case '/meta/handshake':
-            this._socketClientId = message.clientId
-            this._socketSend({
-              advice: { timeout: 0 },
-              channel: '/meta/connect',
-              clientId: this._socketClientId,
-              connectionType: 'websocket',
-              id: this._socketMessageCount,
-            })
-            this.emit('handshake')
-            break
-          case '/meta/connect':
-            if (message.successful) {
-              this.emit('connect', message)
-              this._socketSend({
-                channel: '/meta/connect',
-                clientId: this._socketClientId,
-                connectionType: 'websocket',
-                id: this._socketMessageCount
-              })
-            }
-            break
-          default:
-            this.emit(message.channel, message.data)
-        }
+        this.emit(message.channel, message.data)
       }
     }
   }
 
-  _authenticateSocket() {
-    if (!this._socketInitialized && !this._socketAuthenticating) {
-      this._socketAuthenticating = true
-      this._socket.on('message', (data, flags) => this._socketHandleMessage(data, flags))
-
-      if (this._socket.readyState === this._socket.OPEN) {
-        this.once('handshake', () => {
-          this._socketAuthenticating = false
-          this._socketInitialized = true
-        })
-
-        this._socketSend({
-          advice: {
-            timeout: 60000,
-            interval: 0
-          },
-          channel: '/meta/handshake',
-          ext: { subscriptionId: this._pushSubscriptionId },
-          id: this._socketMessageCounter,
-          minimumVersion: '1.0',
-          supportedConnectionTypes: ['websocket', 'long-polling', 'callback-polling'],
-          version: '1.0'
-        })
-      } else {
-        this._socket.on('open', () => this._authenticateSocket())
+  _authenticateSocket(rehandshake) {
+    if (rehandshake) {
+      this._socketInitialized = false
+      this._socketAuthenticating = false
+    }
+    if (this._socket.readyState === this._socket.OPEN) {
+      if (this._authenticated) {
+        if (!this._socketInitialized) {
+          if (!this._socketAuthenticating) {
+            this._socketAuthenticating = true
+            this._socketSend({
+              advice: {
+                timeout: 60000,
+                interval: 0
+              },
+              channel: '/meta/handshake',
+              ext: { subscriptionId: this._pushSubscriptionId },
+              id: this._socketMessageCounter,
+              minimumVersion: '1.0',
+              supportedConnectionTypes: ['websocket', 'long-polling', 'callback-polling'],
+              version: '1.0'
+            })
+          }
+        } else {
+          this._socketSend({
+            channel: '/meta/connect',
+            clientId: this._socketClientId,
+            connectionType: 'websocket',
+            id: this._socketMessageCount
+          })
+        }
       }
     }
   }
@@ -479,11 +494,9 @@ class Avanza extends EventEmitter {
       throw new Error('Expected to be authenticated before subscribing.')
     }
 
-    if (!this._socketInitialized) {
+    if (!this._socketInitialized || this._socket.readyState != this._socket.OPEN) {
       this.once('connect', () => this.subscribe(channel, ids, callback))
-      if (!this._socketAuthenticating) {
-        this._authenticateSocket()
-      }
+      this._authenticateSocket()
       return
     }
 


### PR DESCRIPTION
This is really 2 different commits. Sorry about that. I can attempt to split them up another day but I didn't have the time and energy right now.

Also the state handling is not extremely pretty.. maybe can be written better but I wanted to commit something now so I can proceed to the next thing. You take it if you want it otherwise I'm happy to discuss how it could be written better.

Two changes:

1. The WebSocket session expires after 24h, when this happens Avanza
will send out a /meta/disconnect after which a new handshake must
be performed before any new operation can take place on the socket.
This code will initiate a new handshake upon reception of
/meta/disconnect or advice.reconnect='handshake'. Note that after
session expiry all subscriptions are lost.

2. In the event the TCP socket drops the 'ws' library will send
an 'close' event after which a new object must be instantiated
to create a new TCP connection. Once this connection is up a
/meta/connect will be sent out and subscriptions will continue
to function.