### PR TITLE
subscribe() validation error should be thrown to caller, not to event loop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -479,14 +479,6 @@ class Avanza extends EventEmitter {
       throw new Error('Expected to be authenticated before subscribing.')
     }
 
-    if (!this._socketInitialized) {
-      this.once('connect', () => this.subscribe(channel, ids, callback))
-      if (!this._socketAuthenticating) {
-        this._authenticateSocket()
-      }
-      return
-    }
-
     if (Array.isArray(ids)) {
       if (
         channel === Avanza.ORDERS ||
@@ -497,6 +489,14 @@ class Avanza extends EventEmitter {
       } else {
         throw new Error(`Channel ${channel} does not support multiple ids as input.`)
       }
+    }
+
+    if (!this._socketInitialized) {
+      this.once('connect', () => this.subscribe(channel, ids, callback))
+      if (!this._socketAuthenticating) {
+        this._authenticateSocket()
+      }
+      return
     }
 
     const subscriptionString = `/${channel}/${ids}`


### PR DESCRIPTION
A malformed subscription() call done when websocket was not up and
initialized would throw an error to the event loop instead of the
caller causing the app to crash (unless an uncaughtException handler
existed).