### PR TITLE
Disconnect() must set this._socketConnected = false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -487,6 +487,8 @@ class Avanza extends EventEmitter {
       this._socket.terminate();
       this._socket = null;
     }
+    this._socketClientId = null;
+    this._socketConnected = false;
     this._pushSubscriptionId = undefined;
     this._socketSubscriptions = {}        // Next startup of websocket should start without subscriptions
   }


### PR DESCRIPTION
If this._socketConnected = true we will attempt to send /meta/subscribe
before socket is up upon next call to subscribe() (which in turn happens
after next call to authenticate()).