### PR TITLE
Resolves issue with nordic letters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ function request(options) {
         'Accept': '*/*',
         'Content-Type': 'application/json',
         'User-Agent': USER_AGENT,
-        'Content-Length': data.length
+        'Content-Length': Buffer.byteLength(data)
       }, options.headers)
     }, (response) => {
       const body = []


### PR DESCRIPTION
Solution for using nordic letters in username. Might need some more testing, but the simple test were I used a username with the letter 'ö' worked fine after this change.